### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,18 @@
 
 My small weekend project, written in [Bevy Engine](https://github.com/bevyengine/bevy). Still **active WIP**! Making it public early in case someone might find this example of simple proc stuff in Bevy useful 😇
 
-To run, download the repo, and run `country-slice.exe`
+## Build and Run
+
+1. download the repo
+2. cd to the `country-slice` directory
+3. execute `cargo build --release`
+4. move the executable from `target/release` to the `country-slice` directory (so that it's with the `assets` directory)
+5. Launch it (`country-slice.exe` on Windows, `./country-slice` on Mac and Linux)
+
+## Compilation problems
+
+You may have compilation problems if some dependencies are missing.
+
+On Debian for example, you may have to do
+
+    sudo apt install libasound2-dev libudev-dev


### PR DESCRIPTION
There were a few problems:

* the executable was making half the repo
* it wasn't designed for any other platform than Windows
* compilation wasn't explained

Now users should probably be more able to compile and execute.

If you want to provide the executables, you should IMO

1. have a script compiling for a few platform (I can provide it)
2. upload the executables with the assets in a "release" on GitHub

BTW, I verified that Country Slice works on Linux and now my kids wants
me to code another game...